### PR TITLE
Add isInt() and isFloat()

### DIFF
--- a/src/tink/Stringly.hx
+++ b/src/tink/Stringly.hx
@@ -51,6 +51,10 @@ abstract Stringly(String) from String to String {
         case 'false', '0', 'no': false;
         default: true;
       }
+      
+  public inline function isFloat() {
+    return isNumber(this.trim(), true);
+  }
     
   @:to public function parseFloat()
     return switch this.trim() {
@@ -62,6 +66,10 @@ abstract Stringly(String) from String to String {
   
   @:to function toFloat()
     return parseFloat().sure();
+    
+  public inline function isInt() {
+    return isNumber(this.trim(), false);
+  }
     
   @:to public function parseInt()
     return switch this.trim() {

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -26,8 +26,10 @@ class RunTests {
   
   public function testParseInt() {
     
-    inline function invalidInt(val:Stringly, ?pos:haxe.PosInfos) 
+    inline function invalidInt(val:Stringly, ?pos:haxe.PosInfos) {
+      asserts.assert(!val.isInt(), pos);
       asserts.assert(!val.parseInt().isSuccess(), pos);
+    }
     
     invalidInt('10g');
     invalidInt('10.34');
@@ -46,8 +48,10 @@ class RunTests {
 
   public function testParseFloat() {
     
-    inline function invalidFloat(val:Stringly, ?pos:haxe.PosInfos) 
+    inline function invalidFloat(val:Stringly, ?pos:haxe.PosInfos) {
+      asserts.assert(!val.isFloat(), pos);
       asserts.assert(!val.parseFloat().isSuccess(), pos);
+    }
     
     invalidFloat('10g');
     invalidFloat('10.34.5');


### PR DESCRIPTION
This should be more performant than `parse().sure()`