### PR TITLE
Fixes #7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.haxe-version == 'nightly' }}
 
     strategy:
       matrix:
@@ -23,6 +24,7 @@ jobs:
           - js
           - cpp
           - php
+          - jvm
 
     steps:
     - name: Check out repo
@@ -55,6 +57,13 @@ jobs:
     - name: Install Haxe Libraries
       run: lix download
       
+    - name: Install Java
+      if: matrix.target == 'jvm'
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 8
+
     - name: Run Test
       run: lix run travix ${{ matrix.target }}
 

--- a/src/tink/Stringly.hx
+++ b/src/tink/Stringly.hx
@@ -104,9 +104,10 @@ abstract Stringly(String) from String to String {
         if(Math.isNaN(date.getTime())) fail() else Success(date);
       #elseif java
         try {
-          var d = java.javax.xml.bind.DatatypeConverter.parseDateTime(this).getTime();
-          Success(new Date(d.getYear() + 1900, d.getMonth(), d.getDate(), d.getHours(), d.getMinutes(), d.getSeconds()));
-        } catch(e:Dynamic) 
+          var epoch = java.time.Instant.parse(this).getEpochSecond();
+          var stamp = (Math.pow(1, 32) * epoch.high) + epoch.low;
+          Success(Date.fromTime(stamp * 1000));
+        } catch(e:Dynamic)
           fail();
       #elseif cs
         try {

--- a/src/tink/Stringly.hx
+++ b/src/tink/Stringly.hx
@@ -103,10 +103,16 @@ abstract Stringly(String) from String to String {
         var date:Date = #if haxe4 js.Syntax.code #else untyped __js__ #end('new Date({0})', this);
         if(Math.isNaN(date.getTime())) fail() else Success(date);
       #elseif java
-        try {
+        var outcome = try {
           var epoch = java.time.Instant.parse(this).getEpochSecond();
           var stamp = (Math.pow(1, 32) * epoch.high) + epoch.low;
           Success(Date.fromTime(stamp * 1000));
+        } catch(e:Dynamic)
+          Failure(new Error("java.time.Instant is not supported"));
+
+        return outcome.isSuccess() ? outcome : try {
+          var d = java.javax.xml.bind.DatatypeConverter.parseDateTime(this).getTime();
+          Success(new Date(d.getYear() + 1900, d.getMonth(), d.getDate(), d.getHours(), d.getMinutes(), d.getSeconds()));
         } catch(e:Dynamic)
           fail();
       #elseif cs

--- a/src/tink/Stringly.hx
+++ b/src/tink/Stringly.hx
@@ -110,7 +110,7 @@ abstract Stringly(String) from String to String {
         } catch(e:Dynamic)
           Failure(new Error("java.time.Instant is not supported"));
 
-        return outcome.isSuccess() ? outcome : try {
+        outcome.isSuccess() ? outcome : try {
           var d = java.javax.xml.bind.DatatypeConverter.parseDateTime(this).getTime();
           Success(new Date(d.getYear() + 1900, d.getMonth(), d.getDate(), d.getHours(), d.getMinutes(), d.getSeconds()));
         } catch(e:Dynamic)


### PR DESCRIPTION
I propose to drop the use of `javax.xml.bind.DatatypeConverter` in favor of `java.time.Instant`, available since Java 8.